### PR TITLE
Changes to make the plugin work in ROS melodic.

### DIFF
--- a/moveit_cartesian_plan_plugin/CMakeLists.txt
+++ b/moveit_cartesian_plan_plugin/CMakeLists.txt
@@ -17,9 +17,9 @@ find_package(catkin REQUIRED COMPONENTS
   tf_conversions
 )
 
-find_package(Qt4 COMPONENTS QtCore QtGui REQUIRED)
-
-include(${QT_USE_FILE})
+# find_package(Qt4 COMPONENTS QtCore QtGui REQUIRED)
+message(STATUS "Using Qt5 based on the rviz_QT_VERSION: ${rviz_QT_VERSION}")
+find_package(Qt5 COMPONENTS Core Widgets Gui Concurrent REQUIRED)
 
 ## I prefer the Qt signals and slots to avoid defining "emit", "slots",
 ## etc because they can conflict with boost signals, so define QT_NO_KEYWORDS here.
@@ -63,14 +63,17 @@ catkin_package(
   rqt_gui_cpp
   visualization_msgs
 )
+include_directories(${moveit_cartesian_plan_plugin_INCLUDE_DIRECTORIES} 
+  ${catkin_INCLUDE_DIRS})
 
-qt4_wrap_cpp(moveit_cartesian_plan_plugin_MOCS ${moveit_cartesian_plan_plugin_HDRS})
-qt4_wrap_ui(moveit_cartesian_plan_plugin_UIS_H ${moveit_cartesian_plan_plugin_UIS})
 
-include_directories(${moveit_cartesian_plan_plugin_INCLUDE_DIRECTORIES} ${catkin_INCLUDE_DIRS})
+qt5_wrap_cpp(moveit_cartesian_plan_plugin_MOCS ${moveit_cartesian_plan_plugin_HDRS})
+qt5_wrap_ui(moveit_cartesian_plan_plugin_UIS_H ${moveit_cartesian_plan_plugin_UIS})
+
 add_library(${PROJECT_NAME} ${moveit_cartesian_plan_plugin_SRCS} ${moveit_cartesian_plan_plugin_MOCS} ${moveit_cartesian_plan_plugin_UIS_H}) # ${moveit_cartesian_plan_plugin_UIS_H}
-target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES} ${QT_QTCORE_LIBRARY} ${QT_QTGUI_LIBRARY} ${moveit_move_group_interface} yaml-cpp)
-## target_link_libraries(${PROJECT_NAME} yaml-cpp)
+target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES} ${moveit_move_group_interface} yaml-cpp)
+
+qt5_use_modules(${PROJECT_NAME} Core Widgets Gui Concurrent)
 
 find_package(class_loader)
 class_loader_hide_library_symbols(${PROJECT_NAME})

--- a/moveit_cartesian_plan_plugin/include/moveit_cartesian_plan_plugin/generate_cartesian_path.h
+++ b/moveit_cartesian_plan_plugin/include/moveit_cartesian_plan_plugin/generate_cartesian_path.h
@@ -1,5 +1,5 @@
 // MoveIt!
-#include <moveit/move_group_interface/move_group.h>
+#include <moveit/move_group_interface/move_group_interface.h>
 #include <moveit/robot_trajectory/robot_trajectory.h>
 #include <moveit/robot_model_loader/robot_model_loader.h>
 
@@ -19,7 +19,7 @@
 #ifndef GENERATE_CARTESIAN_PATH_H_
 #define GENERATE_CARTESIAN_PATH_H_
 
-typedef boost::shared_ptr<move_group_interface::MoveGroup> MoveGroupPtr;
+typedef boost::shared_ptr<moveit::planning_interface::MoveGroupInterface> MoveGroupPtr;
 typedef boost::shared_ptr<robot_model_loader::RobotModelLoader> RobotModelLoaderPtr;
 
 /*!

--- a/moveit_cartesian_plan_plugin/src/generate_cartesian_path.cpp
+++ b/moveit_cartesian_plan_plugin/src/generate_cartesian_path.cpp
@@ -92,7 +92,7 @@ void GenerateCartesianPath::init()
 
   ROS_INFO_STREAM("Group name:"<< group_names[selected_plan_group]);
 
-  moveit_group_ = MoveGroupPtr(new move_group_interface::MoveGroup(group_names[selected_plan_group]));
+  moveit_group_ = MoveGroupPtr(new moveit::planning_interface::MoveGroupInterface(group_names[selected_plan_group]));
   kinematic_state_ = moveit::core::RobotStatePtr(new robot_state::RobotState(kmodel_));
   kinematic_state_->setToDefaultValues();
 
@@ -127,7 +127,7 @@ void GenerateCartesianPath::moveToPose(std::vector<geometry_msgs::Pose> waypoint
     moveit_group_->setPlanningTime(PLAN_TIME_);
     moveit_group_->allowReplanning (MOVEIT_REPLAN_);
 
-    move_group_interface::MoveGroup::Plan plan;
+    moveit::planning_interface::MoveGroupInterface::Plan plan;
 
     moveit_msgs::RobotTrajectory trajectory_;
     double fraction = moveit_group_->computeCartesianPath(waypoints,CART_STEP_SIZE_,CART_JUMP_THRESH_,trajectory_,AVOID_COLLISIONS_);
@@ -243,7 +243,7 @@ void GenerateCartesianPath::getSelectedGroupIndex(int index)
   ROS_INFO_STREAM("selected name is:"<<group_names[selected_plan_group]);
   moveit_group_.reset();
   kinematic_state_.reset();
-  moveit_group_ = MoveGroupPtr(new move_group_interface::MoveGroup(group_names[selected_plan_group]));
+  moveit_group_ = MoveGroupPtr(new moveit::planning_interface::MoveGroupInterface(group_names[selected_plan_group]));
 
   kinematic_state_ = moveit::core::RobotStatePtr(new robot_state::RobotState(kmodel_));
   kinematic_state_->setToDefaultValues();


### PR DESCRIPTION
  *  ``move_group_interface::MoveGroup`` is deprecated in moveit for ROS melodic. Changed to the new namespace and classes.
  *  rviz in melodic uses lib Qt5. Compiling this in Qt4 causes it to segfault. Converted package to Qt5